### PR TITLE
Mostly updating dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-numpy~=1.26.4
-matplotlib~=3.7.2
-pillow~=10.0.0
+numpy>=2.0.0
+matplotlib~=3.9.0
+pillow~=11.0.0
 scipy~=1.14.1
-networkx~=3.1
-scikit-learn~=1.3.0
+networkx~=3.4
+scikit-learn~=1.5.0
 tikzplotlib~=0.10.1
 gurobipy~=11.0.3
-tqdm==4.66.5
+tqdm~=4.66.5


### PR DESCRIPTION
Updating to numpy 2.0+ is backward-compatibility breaking action. Hence, we will bump the version to 1.0